### PR TITLE
Cleanup options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install -g prebuildify
 
 ## Usage
 
-First go to your native module and make a bunch of prebuilds
+First go to your native module and make a bunch of prebuilds.
 
 ``` sh
 # go to your native module
@@ -21,7 +21,7 @@ prebuildify --all --strip
 ls prebuilds
 ```
 
-If your module is using the new node core N-API, then you can prebuild using the `--napi` flag
+If your module is using the new node core [N-API][n-api], then you can prebuild using the `--napi` flag:
 
 ``` sh
 # prebuild for n-api
@@ -38,7 +38,7 @@ Use [node-gyp-build](https://github.com/prebuild/node-gyp-build) to do this.
 npm install --save node-gyp-build
 ```
 
-Then add `node-gyp-build` as an install script to your module's package.json
+Then add `node-gyp-build` as an install script to your module's `package.json`:
 
 ``` js
 {
@@ -49,7 +49,7 @@ Then add `node-gyp-build` as an install script to your module's package.json
 }
 ```
 
-The install script will check if a compatible prebuild is bundled. If so it does nothing. If not it will run `node-gyp rebuild` to produce a build.
+The install script will check if a compatible prebuild is bundled. If so it does nothing. If not it will run [`node-gyp rebuild`][node-gyp] to produce a build.
 This means that if the user using your module has disabled install scripts your module will still work (!) as long as a compatible prebuild is bundled.
 
 When loading your native binding from your `index.js` you should use `node-gyp-build` as will to make sure to get the right binding
@@ -63,12 +63,46 @@ module.exports = binding
 ```
 
 An added benefit of this approach is that your native modules will work across multiple node and electron versions without having the user
-need to reinstall or recompile them - as long as you produce prebuilds for all versions.
+need to reinstall or recompile them - as long as you produce prebuilds for all versions. With N-API you only have to produce prebuilds for every runtime.
 
 When publishing your module to npm remember to include the `./prebuilds` folder.
 
 That's it! Happy native hacking.
 
+## Options
+
+Options can be provided via (in order of precedence) the programmatic API, the CLI or environment variables. The environment variables, whether they are defined on the outside or not, are also made available to subprocesses. For example, `prebuildify --arch arm64 --strip` sets `PREBUILD_ARCH=arm64 PREBUILD_STRIP=1`.
+
+| CLI             | Environment          | Default                        | Description
+|:----------------|:---------------------|:-------------------------------|:------------
+| `--target -t`   | -                    | Depends.                       | One or more targets\*
+| `--all -a`      | -                    | `false`                        | Build all known targets.<br>Takes precedence over `--target`.
+| `--napi`        | -                    | `false`                        | Make [N-API][n-api] build(s).<br>Targets default to node and electron.
+| `--debug`       | -                    | `false`                        | Make Debug build(s)
+| `--arch`        | `PREBUILD_ARCH`      | [`os.arch()`]([os-arch])       | Target architecture\*\*
+| `--platform`    | `PREBUILD_PLATFORM`  | [`os.platform()`][os-platform] | Target platform\*\*
+| `--preinstall`  | -                    | -                              | Command to run before build
+| `--postinstall` | -                    | -                              | Command to run after build
+| `--shell`       | `PREBUILD_SHELL`     | `'sh'` on Android              | Shell to spawn commands in
+| `--artifacts`   | -                    | -                              | Directory containing additional files.<br>Recursively copied into prebuild directory.
+| `--strip`       | `PREBUILD_STRIP`     | `false`                        | Enable [stripping][strip]
+| `--strip-bin`   | `PREBUILD_STRIP_BIN` | `'strip'`                      | Custom strip binary
+| `--node-gyp`    | `PREBUILD_NODE_GYP`  | `'node-gyp(.cmd)'`             | Custom `node-gyp` binary\*\*\*
+| `--quiet`       | -                    | `false`                        | Suppress `node-gyp` output
+| `--cwd`         | -                    | `process.cwd()`                | Working directory
+
+\* A target takes the form of `(runtime@)?version`, where `runtime` defaults to `'node'`. For example: `-t 8.14.0 -t electron@3.0.0`. At least one of `--target`, `--all` or `--napi` must be specified.
+
+\*\* The `arch` option is passed to [`node-gyp`][node-gyp] as `--target-arch`. Target architecture and platform (what you're building _for_) default to the host platform and architecture (what you're building _on_). They can be overridden for cross-compilation, in which case you'll likely also want to override the strip binary. The platform and architecture dictate the output folder. For example on Linux x64 prebuilds end up in `prebuilds/linux-x64`.
+
+\*\*\* To enable the use of forks like [`nodejs-mobile-gyp`](https://www.npmjs.com/package/nodejs-mobile-gyp).
+
 ## License
 
 MIT
+
+[n-api]: https://nodejs.org/api/n-api.html
+[node-gyp]: https://www.npmjs.com/package/node-gyp
+[os-arch]: https://nodejs.org/api/os.html#os_os_arch
+[os-platform]: https://nodejs.org/api/os.html#os_os_platform
+[strip]: https://en.wikipedia.org/wiki/Strip_%28Unix%29

--- a/bin.js
+++ b/bin.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 var minimist = require('minimist')
-var abi = require('node-abi')
 var prebuildify = require('./index')
 
 var argv = minimist(process.argv.slice(2), {
@@ -13,34 +12,10 @@ var argv = minimist(process.argv.slice(2), {
     stripBin: 'strip-bin',
     nodeGyp: 'node-gyp'
   },
-  boolean: ['quiet', 'strip', 'napi', 'debug']
+  boolean: ['quiet', 'strip', 'napi', 'debug', 'all']
 })
 
-var targets = [].concat(argv.target || []).map(function (v) {
-  if (v.indexOf('@') === -1) v = 'node@' + v
-
-  return {
-    runtime: v.split('@')[0],
-    target: v.split('@')[1].replace(/^v/, '')
-  }
-})
-
-// TODO: also support --lts and get versions from travis
-if (argv.all) {
-  targets = abi.supportedTargets.slice(0)
-}
-
-// Should be the default once napi is stable
-if (argv.napi && targets.length === 0) {
-  targets = [
-    abi.supportedTargets.filter(onlyNode).pop(),
-    abi.supportedTargets.filter(onlyElectron).pop()
-  ]
-
-  if (targets[0].target === '9.0.0') targets[0].target = '9.6.1'
-}
-
-argv.targets = targets
+argv.targets = [].concat(argv.target || [])
 argv.cwd = argv.cwd || argv._[0] || '.'
 
 prebuildify(argv, function (err) {
@@ -49,11 +24,3 @@ prebuildify(argv, function (err) {
     process.exit(1)
   }
 })
-
-function onlyNode (t) {
-  return t.runtime === 'node'
-}
-
-function onlyElectron (t) {
-  return t.runtime === 'electron'
-}

--- a/bin.js
+++ b/bin.js
@@ -5,8 +5,15 @@ var abi = require('node-abi')
 var prebuildify = require('./index')
 
 var argv = minimist(process.argv.slice(2), {
-  alias: {target: 't', version: 'v', all: 'a', napi: 'n-api'},
-  boolean: ['quiet', 'strip']
+  alias: {
+    target: 't',
+    version: 'v',
+    all: 'a',
+    napi: 'n-api',
+    stripBin: 'strip-bin',
+    nodeGyp: 'node-gyp'
+  },
+  boolean: ['quiet', 'strip', 'napi', 'debug']
 })
 
 var targets = [].concat(argv.target || []).map(function (v) {

--- a/index.js
+++ b/index.js
@@ -171,10 +171,11 @@ function findBuild (dir, cb) {
 }
 
 function strip (file, opts, cb) {
-  if (!opts.strip || (opts.platform !== 'darwin' && opts.platform !== 'linux')) return cb()
+  var platform = os.platform()
+  if (!opts.strip || (platform !== 'darwin' && platform !== 'linux')) return cb()
 
-  var args = opts.platform === 'darwin' ? [file, '-Sx'] : [file, '--strip-all']
   var stripBin = process.env.STRIP || 'strip'
+  var args = platform === 'darwin' ? [file, '-Sx'] : [file, '--strip-all']
   var child = proc.spawn(stripBin, args, {stdio: 'ignore'})
 
   child.on('exit', function (code) {


### PR DESCRIPTION
Implements the plan outlined in https://github.com/prebuild/prebuildify/pull/22#issuecomment-471189585. Supersedes #22 (I cherry-picked 9749d47ed926dddaf940d9afb0c5039f490c4a58), closes #21, closes #16. Also fixes the working directory for the pre/post hooks, which had a typo (`cmd` instead of `cwd`).

This is a breaking change. I suggest that we also try to include the new naming scheme (#25) in a next major.