### PR TITLE
Clarify --all precedence over --napi

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ If your module is using the new node core [N-API][n-api], then you can prebuild 
 prebuildify --napi
 ```
 
-Note that the flags `--all` and `--target` can add additional targets to the build, which likely are incompatible with N-API. Start with only the `--napi` flag, it should be sufficient for most scenarios.
-
 Then only remaining thing you need to do now is make your module use a prebuild if one exists
 for the platform/runtime you are using.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Options can be provided via (in order of precedence) the programmatic API, the C
 | CLI             | Environment          | Default                        | Description
 |:----------------|:---------------------|:-------------------------------|:------------
 | `--target -t`   | -                    | Depends.                       | One or more targets\*
-| `--all -a`      | -                    | `false`                        | Build all known targets.<br>Takes precedence over `--target` and `--napi`.
+| `--all -a`      | -                    | `false`                        | Build all known targets.<br>Takes precedence over `--target` and over `--napi`.
 | `--napi`        | -                    | `false`                        | Make [N-API][n-api] build(s).<br>Targets default to node and electron.
 | `--debug`       | -                    | `false`                        | Make Debug build(s)
 | `--arch`        | `PREBUILD_ARCH`      | [`os.arch()`]([os-arch])       | Target architecture\*\*

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ If your module is using the new node core [N-API][n-api], then you can prebuild 
 prebuildify --napi
 ```
 
+Note that the flags `--all` and `--target` can add additional targets to the build, which likely are incompatible with N-API. Start with only the `--napi`flag, it should be sufficient for most scenarios.
+
 Then only remaining thing you need to do now is make your module use a prebuild if one exists
 for the platform/runtime you are using.
 
@@ -82,7 +84,7 @@ Options can be provided via (in order of precedence) the programmatic API, the C
 | CLI             | Environment          | Default                        | Description
 |:----------------|:---------------------|:-------------------------------|:------------
 | `--target -t`   | -                    | Depends.                       | One or more targets\*
-| `--all -a`      | -                    | `false`                        | Build all known targets.<br>Takes precedence over `--target` and over `--napi`.
+| `--all -a`      | -                    | `false`                        | Build all known targets.<br>Takes precedence over `--target`.
 | `--napi`        | -                    | `false`                        | Make [N-API][n-api] build(s).<br>Targets default to latest node and electron, which can be overridden with `--all` or `--target`.
 | `--debug`       | -                    | `false`                        | Make Debug build(s)
 | `--arch`        | `PREBUILD_ARCH`      | [`os.arch()`]([os-arch])       | Target architecture\*\*

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Options can be provided via (in order of precedence) the programmatic API, the C
 |:----------------|:---------------------|:-------------------------------|:------------
 | `--target -t`   | -                    | Depends.                       | One or more targets\*
 | `--all -a`      | -                    | `false`                        | Build all known targets.<br>Takes precedence over `--target` and over `--napi`.
-| `--napi`        | -                    | `false`                        | Make [N-API][n-api] build(s).<br>Targets default to node and electron.
+| `--napi`        | -                    | `false`                        | Make [N-API][n-api] build(s).<br>Targets default to latest node and electron, which can be overridden with `--all` or `--target`.
 | `--debug`       | -                    | `false`                        | Make Debug build(s)
 | `--arch`        | `PREBUILD_ARCH`      | [`os.arch()`]([os-arch])       | Target architecture\*\*
 | `--platform`    | `PREBUILD_PLATFORM`  | [`os.platform()`][os-platform] | Target platform\*\*

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If your module is using the new node core [N-API][n-api], then you can prebuild 
 prebuildify --napi
 ```
 
-Note that the flags `--all` and `--target` can add additional targets to the build, which likely are incompatible with N-API. Start with only the `--napi`flag, it should be sufficient for most scenarios.
+Note that the flags `--all` and `--target` can add additional targets to the build, which likely are incompatible with N-API. Start with only the `--napi` flag, it should be sufficient for most scenarios.
 
 Then only remaining thing you need to do now is make your module use a prebuild if one exists
 for the platform/runtime you are using.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Options can be provided via (in order of precedence) the programmatic API, the C
 |:----------------|:---------------------|:-------------------------------|:------------
 | `--target -t`   | -                    | Depends.                       | One or more targets\*
 | `--all -a`      | -                    | `false`                        | Build all known targets.<br>Takes precedence over `--target`.
-| `--napi`        | -                    | `false`                        | Make [N-API][n-api] build(s).<br>Targets default to latest node and electron, which can be overridden with `--all` or `--target`.
+| `--napi`        | -                    | `false`                        | Make [N-API][n-api] build(s).<br>Targets default to latest node and electron, which can be overridden with `--target`. Note: `--all` should be avoided for now because it includes targets that don't support N-API.
 | `--debug`       | -                    | `false`                        | Make Debug build(s)
 | `--arch`        | `PREBUILD_ARCH`      | [`os.arch()`]([os-arch])       | Target architecture\*\*
 | `--platform`    | `PREBUILD_PLATFORM`  | [`os.platform()`][os-platform] | Target platform\*\*

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Options can be provided via (in order of precedence) the programmatic API, the C
 | CLI             | Environment          | Default                        | Description
 |:----------------|:---------------------|:-------------------------------|:------------
 | `--target -t`   | -                    | Depends.                       | One or more targets\*
-| `--all -a`      | -                    | `false`                        | Build all known targets.<br>Takes precedence over `--target`.
+| `--all -a`      | -                    | `false`                        | Build all known targets.<br>Takes precedence over `--target` and `--napi`.
 | `--napi`        | -                    | `false`                        | Make [N-API][n-api] build(s).<br>Targets default to node and electron.
 | `--debug`       | -                    | `false`                        | Make Debug build(s)
 | `--arch`        | `PREBUILD_ARCH`      | [`os.arch()`]([os-arch])       | Target architecture\*\*


### PR DESCRIPTION
A minor tweak to the docs, but one that would have spared myself some frustration. I enabled `--all` since I wanted all sensible targets for N-API, but running `prebuildify --all --napi` did not work for me. My conclusion is that `--all` takes precedence over `--napi`.