### PR TITLE
Upgrade node-abi

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [8, 10, 12, 14, 16]
+        node: [10, 12, 14, 16]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} / Node ${{ matrix.node }}
     steps:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "execspawn": "^1.0.1",
     "mkdirp-classic": "^0.5.3",
-    "node-abi": "^2.19.1",
+    "node-abi": "^3.3.0",
     "npm-run-path": "^3.1.0",
     "minimist": "^1.2.5",
     "pump": "^3.0.0",


### PR DESCRIPTION
Node V17 doesn't compile for me without upgrading the node-abi package, so this just upgrades it.