### PR TITLE
Add --exclude-target to exclude targets when using --all

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -6,6 +6,7 @@ var prebuildify = require('./index')
 var argv = minimist(process.argv.slice(2), {
   alias: {
     target: 't',
+    excludeTarget: ['exclude-target', 'x'],
     version: 'v',
     all: 'a',
     napi: 'n-api',
@@ -21,6 +22,7 @@ var argv = minimist(process.argv.slice(2), {
 })
 
 argv.targets = [].concat(argv.target || [])
+argv.excludedTargets = [].concat(argv.excludeTarget || [])
 argv.cwd = argv.cwd || argv._[0] || '.'
 
 prebuildify(argv, function (err) {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ function prebuildify (opts, cb) {
     nodeGyp: process.env.PREBUILD_NODE_GYP || npmbin('node-gyp'),
     shell: process.env.PREBUILD_SHELL || shell(),
     cwd: '.',
-    targets: []
+    targets: [],
+    excludedTargets: [],
   }, opts)
 
   if (!opts.armv) {
@@ -36,7 +37,7 @@ function prebuildify (opts, cb) {
     opts.out = opts.cwd
   }
 
-  var targets = resolveTargets(opts.targets, opts.all, opts.napi, opts.electronCompat)
+  var targets = resolveTargets(opts.targets, opts.all, opts.napi, opts.electronCompat, opts.excludedTargets)
 
   if (!targets.length) {
     return process.nextTick(cb, new Error('You must specify at least one target'))
@@ -285,16 +286,18 @@ function shell () {
   return os.platform() === 'android' ? 'sh' : undefined
 }
 
-function resolveTargets (targets, all, napi, electronCompat) {
-  targets = targets.map(function (v) {
-    if (typeof v === 'object' && v !== null) return v
-    if (v.indexOf('@') === -1) v = 'node@' + v
+function parseTarget(v) {
+  if (typeof v === 'object' && v !== null) return v
+  if (v.indexOf('@') === -1) v = 'node@' + v
 
-    return {
-      runtime: v.split('@')[0],
-      target: v.split('@')[1].replace(/^v/, '')
-    }
-  })
+  return {
+    runtime: v.split('@')[0],
+    target: v.split('@')[1].replace(/^v/, '')
+  }
+}
+
+function resolveTargets (targets, all, napi, electronCompat, excludedTargets) {
+  targets = targets.map(parseTarget)
 
   // TODO: also support --lts and get versions from travis
   if (all) {
@@ -312,6 +315,13 @@ function resolveTargets (targets, all, napi, electronCompat) {
 
     if (targets[0].target === '9.0.0') targets[0].target = '9.6.1'
   }
+
+  excludedTargets = excludedTargets.map(parseTarget)
+  targets = targets.filter(function (a) {
+    return !excludedTargets.find(function (b) {
+      return a.runtime === b.runtime && a.target === b.target
+    })
+  })
 
   return targets
 }


### PR DESCRIPTION
As I mentioned in #61, sometimes I'd like to exclude some older targets from the list node-abi gives you when you do --all.﻿
