### PR TITLE
Update Electron headers download path (resolves #67)

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ function build (target, runtime, opts, cb) {
 
   if (runtime === 'electron') {
     args.push('--runtime=electron')
-    args.push('--dist-url=https://atom.io/download/electron')
+    args.push('--dist-url=https://electronjs.org/headers')
   } else if (runtime === 'node' && [10, 11].some(buggedMajor => +target.split('.')[0] === buggedMajor)) {
     // work around a build bug in node versions 10 and 11 https://github.com/nodejs/node-gyp/issues/1457
     args.push('--build_v8_with_gn=false')


### PR DESCRIPTION
The old path points to atom.io, which now has a 403 Forbidden if trying to download headers from there. This PR updates the path to the newer electron site path.

(Resolves #67)