### PR TITLE
Support tag options via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ Options can be provided via (in order of precedence) the programmatic API, the C
 | `--uv`               | `PREBUILD_UV`        | From `process.versions.uv`     | Major libuv version\*\*\*
 | `--armv`             | `PREBUILD_ARMV`      | Auto-detected on ARM machines  | Numeric ARM version (e.g. 7)\*\*\*
 | `--libc`             | `PREBUILD_LIBC`      | `glibc`, `musl` on Alpine      | libc flavor\*\*\*
-| `--tag-uv`           | -                    | `false`                        | Tag prebuild with `uv`\*\*\*
-| `--tag-armv`         | -                    | `false`                        | Tag prebuild with `armv`\*\*\*
-| `--tag-libc`         | -                    | `false`                        | Tag prebuild with `libc`\*\*\*
+| `--tag-uv`           | `PREBUILD_TAG_UV`    | `false`                        | Tag prebuild with `uv`\*\*\*
+| `--tag-armv`         | `PREBUILD_TAG_ARMV`  | `false`                        | Tag prebuild with `armv`\*\*\*
+| `--tag-libc`         | `PREBUILD_TAG_LIBC`  | `false`                        | Tag prebuild with `libc`\*\*\*
 | `--preinstall`       | -                    | -                              | Command to run before build
 | `--postinstall`      | -                    | -                              | Command to run after build
 | `--shell`            | `PREBUILD_SHELL`     | `'sh'` on Android              | Shell to spawn commands in

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ function prebuildify (opts, cb) {
     stripBin: process.env.PREBUILD_STRIP_BIN || 'strip',
     nodeGyp: process.env.PREBUILD_NODE_GYP || npmbin('node-gyp'),
     shell: process.env.PREBUILD_SHELL || shell(),
+    tagUv: process.env.PREBUILD_TAG_UV === '1' ? true : process.env.PREBUILD_TAG_UV,
+    tagArmv: process.env.PREBUILD_TAG_ARMV === '1' ? true : process.env.PREBUILD_TAG_ARMV,
+    tagLibc: process.env.PREBUILD_TAG_LIBC === '1' ? true : process.env.PREBUILD_TAG_LIBC,
     cwd: '.',
     targets: []
   }, opts)
@@ -53,7 +56,10 @@ function prebuildify (opts, cb) {
       PREBUILD_STRIP: opts.strip ? '1' : '0',
       PREBUILD_STRIP_BIN: opts.stripBin,
       PREBUILD_NODE_GYP: opts.nodeGyp,
-      PREBUILD_SHELL: opts.shell
+      PREBUILD_SHELL: opts.shell,
+      PREBUILD_TAG_UV: opts.tagUv,
+      PREBUILD_TAG_ARMV: opts.tagArmv,
+      PREBUILD_TAG_LIBC: opts.tagLibc
     }),
     builds: path.join(opts.out, 'prebuilds', opts.platform + '-' + opts.arch),
     output: path.join(opts.cwd, 'build', opts.debug ? 'Debug' : 'Release')

--- a/test/api.js
+++ b/test/api.js
@@ -45,6 +45,31 @@ test('uv, armv and libc tags', function (t) {
   })
 })
 
+test('uv, armv and libc tags from env var', function (t) {
+  process.env.PREBUILD_TAG_UV = '321'
+  process.env.PREBUILD_TAG_ARMV = '1' // Should be excluded (unless you run these tests on ARM)
+  process.env.PREBUILD_TAG_LIBC = '1' // Should be glibc (unless you run these tests on Alpine)
+  prebuildify({
+    cwd: path.join(__dirname, 'package'),
+    targets: [{ runtime: 'node', target: process.version }]
+  }, function (err) {
+    t.ifError(err)
+    t.doesNotThrow(function () {
+      var folder = os.platform() + '-' + os.arch()
+      var name = [
+        'node',
+        'abi' + process.versions.modules,
+        'uv321',
+        'glibc',
+        'node'
+      ].join('.')
+      var addon = require(path.join(__dirname, 'package', 'prebuilds', folder, name))
+      t.equal(addon.check(), 'prebuildify')
+    })
+    t.end()
+  })
+})
+
 gt8 && test('prefers locally installed node-gyp bin', function (t) {
   prebuildify({
     cwd: path.join(__dirname, 'mock-gyp'),


### PR DESCRIPTION
This PR introduces support for allowing the user to pass the --tag-uv, --tag-armv and --tag-libc options through environment variables PREBUILD_TAG_UV, PREBUILD_TAG_ARMV and PREBUILD_TAG_LIBC (respectively).

Setting the environment variable to '1' has the same effect as specifying the corresponding option from the command line by itself (i.e. `PREBUILD_TAG_ARMV=1` is the same as `--tag-uv`) and setting it to any other value different than '1' has the same effect as specifying that value to the CLI option (i.e. `PREBUILD_TAG_ARMV=foo` is the same as `--tag-uv foo`).