### PR TITLE
Support cmake-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Options can be provided via (in order of precedence) the programmatic API, the C
 | `--node-gyp`         | `PREBUILD_NODE_GYP`  | `'node-gyp(.cmd)'`             | Custom `node-gyp` binary\*\*\*\*
 | `--quiet`            | -                    | `false`                        | Suppress `node-gyp` output
 | `--cwd`              | -                    | `process.cwd()`                | Working directory
+| `--backend`          | -                    | `node-gyp`                     | The build backend to use, e.g. `cmake-js`
 
 \* A target takes the form of `(runtime@)?version`, where `runtime` defaults to `'node'`. For example: `-t 8.14.0 -t electron@3.0.0`. At least one of `--target`, `--all` or `--napi` must be specified.
 
@@ -111,6 +112,12 @@ Options can be provided via (in order of precedence) the programmatic API, the C
 \*\*\* The filenames of prebuilds are composed of _tags_ which by default include runtime and either `napi` or `abi<version>`. For example: `electron.abi40.node`. To make more specific prebuilds (for `node-gyp-build` to select) you can add additional tags. Values for these tags are auto-detected. For example, `--napi --tag-uv --tag-armv` could result in a build called `node.napi.uv1.armv8.node` if the host machine has an ARM architecture. When cross-compiling you can override values either through the relevant option (`--tag-armv --armv 7`) or the tag (`--tag-armv 7`) as a shortcut. They're separate because you may want to build a certain version without tagging the prebuild as such, assuming that the prebuild is forward compatible.
 
 \*\*\*\* To enable the use of forks like [`nodejs-mobile-gyp`](https://www.npmjs.com/package/nodejs-mobile-gyp).
+
+When using the `cmake-js` backend additional parameters can be passed through.
+
+```
+prebuildify --backend cmake-js -- --prefer-clang --CDUV_INCLUDE_DIR=...
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Create and package prebuilds for native modules",
   "main": "index.js",
   "dependencies": {
+    "cmake-js": "^7.2.1",
     "execspawn": "^1.0.1",
     "mkdirp-classic": "^0.5.3",
     "node-abi": "^3.3.0",
     "npm-run-path": "^3.1.0",
+    "npm-which": "^3.0.1",
     "minimist": "^1.2.5",
     "pump": "^3.0.0",
     "tar-fs": "^2.1.0"


### PR DESCRIPTION
Fixes https://github.com/prebuild/prebuildify/issues/49

This PR adds support for driving `cmake-js` in the same way as `prebuild` by using the `--backend` flag. e.g.:

```
prebuildify --backend cmake-js -- --prefer-clang
```