### PR TITLE
(fix) Ensure runtime and napi are emitted as needed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,9 +129,17 @@ function encodeName (name) {
 }
 
 function prebuildName (target, opts) {
-  var tags = [encodeName(opts.name || target.runtime)]
+  var tags = []
 
-  if (!opts.napi) {
+  if (opts.name) {
+    tags.push(encodeName(opts.name))
+  }
+
+  tags.push(target.runtime)
+
+  if (opts.napi) {
+    tags.push('napi')
+  } else {
     tags.push('abi' + abi.getAbi(target.target, target.runtime))
   }
 

--- a/test/api.js
+++ b/test/api.js
@@ -12,7 +12,31 @@ test('build with current node version', function (t) {
     t.ifError(err)
     t.doesNotThrow(function () {
       var folder = os.platform() + '-' + os.arch()
-      var name = 'addon.abi' + process.versions.modules + '.node'
+      var name = 'addon.node.abi' + process.versions.modules + '.node'
+      var addon = require(path.join(__dirname, 'package', 'prebuilds', folder, name))
+      t.equal(addon.check(), 'prebuildify')
+    })
+    t.end()
+  })
+})
+
+test('runtime napi flags', function (t) {
+  prebuildify({
+    cwd: path.join(__dirname, 'package'),
+    targets: [{ runtime: 'node', target: process.version }],
+    napi: true,
+    tagLibc: true // Should be glibc (unless you run these tests on Alpine)
+  }, function (err) {
+    t.ifError(err)
+    t.doesNotThrow(function () {
+      var folder = os.platform() + '-' + os.arch()
+      var name = [
+        'addon',
+        'node',
+        'napi',
+        'glibc',
+        'node'
+      ].join('.')
       var addon = require(path.join(__dirname, 'package', 'prebuilds', folder, name))
       t.equal(addon.check(), 'prebuildify')
     })
@@ -33,6 +57,7 @@ test('uv, armv and libc tags', function (t) {
       var folder = os.platform() + '-' + os.arch()
       var name = [
         'addon',
+        'node',
         'abi' + process.versions.modules,
         'uv123',
         'glibc',


### PR DESCRIPTION
Fixes issue #79.
There seems to be a regression introduced in 7b6dcbd which caused the `target.runtime` to no longer be emitted when a name is used. A name is also _always_ used even if not passed, as it will grab a name from the `package.json`. This commit also dropped including the `napi` tag, which is still utilized downstream.

This change fixes the regression and follows this logic;

1. Emit `name` as a tag (this will always be true due to `addName` function logic)
2. Emit `runtime` as a tag always
3. Emit `napi` as a tag if option enabled (likely always true, as it if defaulted to true)