### PR TITLE
chore: update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ var os = require('os')
 var path = require('path')
 var fs = require('fs')
 var abi = require('node-abi')
-var mkdirp = require('mkdirp-classic')
 var tar = require('tar-fs')
 var pump = require('pump')
 var npmRunPath = require('npm-run-path')
@@ -68,7 +67,7 @@ function prebuildify (opts, cb) {
 
   addName(opts, function (err) {
     if (err) return cb(err)
-    mkdirp(opts.builds, function (err) {
+    fs.mkdir(opts.builds, { recursive: true }, function (err) {
       if (err) return cb(err)
       loop(opts, function (err) {
         if (err) return cb(err)
@@ -226,7 +225,7 @@ function build (target, runtime, opts, cb) {
     args.push('--release')
   }
 
-  mkdirp(cache, function () {
+  fs.mkdir(cache, { recursive: true }, function () {
     var child = proc.spawn(opts.nodeGyp, args, {
       cwd: opts.cwd,
       env: opts.env,

--- a/package.json
+++ b/package.json
@@ -4,17 +4,16 @@
   "description": "Create and package prebuilds for native modules",
   "main": "index.js",
   "dependencies": {
-    "minimist": "^1.2.5",
-    "mkdirp-classic": "^0.5.3",
-    "node-abi": "^3.3.0",
-    "npm-run-path": "^3.1.0",
+    "minimist": "^1.2.8",
+    "node-abi": "^3.62.0",
+    "npm-run-path": "^4.0.1",
     "pump": "^3.0.0",
-    "tar-fs": "^2.1.0"
+    "tar-fs": "^3.0.5"
   },
   "devDependencies": {
-    "nan": "^2.14.2",
-    "standard": "^13.0.1",
-    "tape": "^4.6.3"
+    "nan": "^2.19.0",
+    "standard": "^14.3.4",
+    "tape": "^5.7.5"
   },
   "bin": {
     "prebuildify": "./bin.js"


### PR DESCRIPTION
I could not update `npm-run-path` to v5.3.0 because it's an ES module.

~~The second commit replaces the `execspawn` and `mkdirp` usages. I can drop it if you want.~~