### PR TITLE
bump node-abi from 3.3.0 to 3.58.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "execspawn": "^1.0.1",
     "mkdirp-classic": "^0.5.3",
-    "node-abi": "^3.3.0",
+    "node-abi": "^3.58.0",
     "npm-run-path": "^3.1.0",
     "minimist": "^1.2.5",
     "pump": "^3.0.0",


### PR DESCRIPTION
adds support for Node.js v21 (abi 120)