### PR TITLE
Correctly handle Override of napi on manually specifying targets

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,33 +1,10 @@
 #!/usr/bin/env node
 
-var minimist = require('minimist')
+
 var prebuildify = require('./index')
+var parseArgs = require('./parse.js')
 
-var argv = minimist(process.argv.slice(2), {
-  alias: {
-    name: 'n',
-    target: 't',
-    version: 'v',
-    all: 'a',
-    napi: 'n-api',
-    stripBin: 'strip-bin',
-    nodeGyp: 'node-gyp',
-    tagUv: 'tag-uv',
-    tagArmv: 'tag-armv',
-    tagLibc: 'tag-libc',
-    electronCompat: 'electron-compat',
-    cache: 'c'
-  },
-  boolean: ['quiet', 'strip', 'napi', 'debug', 'all', 'electron-compat'],
-  default: {
-    napi: true
-  }
-})
-
-argv.targets = [].concat(argv.target || [])
-argv.cwd = argv.cwd || argv._[0] || '.'
-
-prebuildify(argv, function (err) {
+prebuildify(parseArgs(process.argv.slice(2)), function (err) {
   if (err) {
     console.error(err.message || err)
     process.exit(1)

--- a/index.js
+++ b/index.js
@@ -35,6 +35,11 @@ function prebuildify (opts, cb) {
     opts.out = opts.cwd
   }
 
+  // if we supply some targets manually, disable the napi build
+  if (opts.targets.length !== 0) {
+    opts.napi = false;
+  }
+
   var targets = resolveTargets(opts.targets, opts.all, opts.napi, opts.electronCompat)
 
   if (!targets.length) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "files": [
     "bin.js",
-    "index.js"
+    "index.js",
+    "parse.js"
   ],
   "scripts": {
     "lint": "standard",

--- a/parse.js
+++ b/parse.js
@@ -1,0 +1,33 @@
+
+var minimist = require('minimist')
+
+module.exports = parseArgs
+
+function parseArgs(argv) {
+
+    var options = minimist(argv, {
+        alias: {
+            name: 'n',
+            target: 't',
+            version: 'v',
+            all: 'a',
+            napi: 'n-api',
+            stripBin: 'strip-bin',
+            nodeGyp: 'node-gyp',
+            tagUv: 'tag-uv',
+            tagArmv: 'tag-armv',
+            tagLibc: 'tag-libc',
+            electronCompat: 'electron-compat',
+            cache: 'c'
+        },
+        boolean: ['quiet', 'strip', 'napi', 'debug', 'all', 'electron-compat'],
+        default: {
+            napi: true
+        }
+    })
+
+    options.targets = [].concat(options.target || [])
+    options.cwd = options.cwd || options._[0] || '.'
+
+    return options
+}

--- a/test/api.js
+++ b/test/api.js
@@ -2,6 +2,8 @@ var test = require('tape')
 var path = require('path')
 var os = require('os')
 var prebuildify = require('../')
+var parseArgs = require('../parse.js')
+
 var gt8 = process.version.match(/^v(\d+)\./)[1] > 8
 
 test('build with current node version', function (t) {
@@ -54,3 +56,25 @@ gt8 && test('prefers locally installed node-gyp bin', function (t) {
     t.end()
   })
 })
+
+
+test('real world scenario: abi tags', function (t) {
+
+  var parsedOpts = parseArgs(["-t", process.version])
+
+  prebuildify(parsedOpts, function (err) {
+    t.ifError(err)
+    t.doesNotThrow(function () {
+      var folder = os.platform() + '-' + os.arch()
+      var name = [
+        'addon',
+        'abi' + process.versions.modules,
+        'node'
+      ].join('.')
+      var addon = require(path.join(__dirname, 'package', 'prebuilds', folder, name))
+      t.equal(addon.check(), 'prebuildify')
+    })
+    t.end()
+  })
+})
+


### PR DESCRIPTION
Fixes #90

- add test, that uses "real worlds scenario" by using really parsed options, not just artificially generated options

- to make this tests possible, I had to factor the function, that parses the args out, and make a separate file


the fix was relative simple, see [here](https://github.com/prebuild/prebuildify/pull/91/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R38-R42)

The rest just refactors the files, to be able to test this, and have no regressions in the future
